### PR TITLE
Move Blogs section below Invited Talks and add numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,6 @@ A recognized thought leader, Hariharan has delivered invited talks at ACM, OWASP
 [shufflecards](https://github.com/hariharanragothaman/shufflecards): Shuffle order problem ![Stars](https://img.shields.io/github/stars/hariharanragothaman/shufflecards?style=flat&color=gold) <br>
 [graphicbay](https://github.com/hariharanragothaman/graphicbay): C++ program for basic E-commerce system [Archived] ![Stars](https://img.shields.io/github/stars/hariharanragothaman/graphicbay?style=flat&color=gold)
 
-### Blogs
-
-[NimbusNet: Building a High-Performance Echo & Chat Server Across Boost.Asio and io_uring](https://hackernoon.com/nimbusnet-building-a-highperformance-echo-and-chat-server-across-boostasio-and-io_uring) — Deep dive into low-latency TCP/UDP server design using Boost.Asio and Linux io_uring
-
 ### Invited Talks
 
 18\. [The Real ROI of your Cloud Strategy](https://www.red-gate.com/hub/events/redgate-summit-2025-dallas), RedGate Summit, Dallas 2025 <br>
@@ -73,6 +69,10 @@ A recognized thought leader, Hariharan has delivered invited talks at ACM, OWASP
 3\. Artificial Intelligence Driven Automation in DevOps - Transforming Security and Resilience, ICMR 2024 <br>
 2\. Improving Code Quality through Continuous Integration Testing, Bose Technical Conference (BTC-2017), Boston, USA <br>
 1\. Establishing Design Routines for Effective Control of Automated Robots, VIMANTRA 2012, National Instruments, India
+
+### Blogs
+
+1\. [NimbusNet: Building a High-Performance Echo & Chat Server Across Boost.Asio and io_uring](https://hackernoon.com/nimbusnet-building-a-highperformance-echo-and-chat-server-across-boostasio-and-io_uring) — Deep dive into low-latency TCP/UDP server design using Boost.Asio and Linux io_uring
 
 ### Tech Stack
 


### PR DESCRIPTION
## Summary
- Move the Blogs section from above Invited Talks to below it
- Add numbering to blog entries for consistency with the Invited Talks format

## Test plan
- Verify section ordering: Open Source Projects → Invited Talks → Blogs → Tech Stack
- Confirm blog entry is numbered

Made with [Cursor](https://cursor.com)